### PR TITLE
Graph IO speedup

### DIFF
--- a/lib/io/graph_io.cpp
+++ b/lib/io/graph_io.cpp
@@ -40,7 +40,7 @@ int graph_io::writeGraphWeighted(graph_access & G, std::string filename) {
                 forall_out_edges(G, e, node) {
                         f << " " <<   (G.getEdgeTarget(e)+1) <<  " " <<  G.getEdgeWeight(e) ;
                 } endfor 
-                f <<  std::endl;
+                f <<  "\n";
         } endfor
 
         f.close();
@@ -55,7 +55,7 @@ int graph_io::writeGraph(graph_access & G, std::string filename) {
                 forall_out_edges(G, e, node) {
                         f <<   (G.getEdgeTarget(e)+1) << " " ;
                 } endfor 
-                f <<  std::endl;
+                f <<  "\n";
         } endfor
 
         f.close();
@@ -211,7 +211,7 @@ void graph_io::writePartition(graph_access & G, std::string filename) {
         std::cout << "writing partition to " << filename << " ... " << std::endl;
 
         forall_nodes(G, node) {
-                f << G.getPartitionIndex(node) <<  std::endl;
+                f << G.getPartitionIndex(node) <<  "\n";
         } endfor
 
         f.close();

--- a/parallel/parallel_src/lib/io/parallel_graph_io.cpp
+++ b/parallel/parallel_src/lib/io/parallel_graph_io.cpp
@@ -652,8 +652,8 @@ int parallel_graph_io::writeGraphParallelSimple(parallel_graph_access & G,
                 forall_local_nodes(G, node) {
                         forall_out_edges(G, e, node) {
                                 f << (G.getGlobalID(G.getEdgeTarget(e))+1) << " " ;
-                        } endfor 
-                        f <<  std::endl;
+                        } endfor
+                        f <<  "\n";
                 } endfor
 
                 f.close();
@@ -669,7 +669,7 @@ int parallel_graph_io::writeGraphParallelSimple(parallel_graph_access & G,
                                 forall_out_edges(G, e, node) {
                                         f <<  (G.getGlobalID(G.getEdgeTarget(e))+1) << " " ;
                                 } endfor 
-                                f <<  std::endl;
+                                f <<  "\n";
                         } endfor
                         f.close();
                 }

--- a/parallel/parallel_src/lib/io/parallel_graph_io.cpp
+++ b/parallel/parallel_src/lib/io/parallel_graph_io.cpp
@@ -695,7 +695,7 @@ int parallel_graph_io::writeGraphWeightedParallelSimple(parallel_graph_access & 
                         forall_out_edges(G, e, node) {
                                 f << " " <<   (G.getGlobalID(G.getEdgeTarget(e))+1) <<  " " <<  G.getEdgeWeight(e) ;
                         } endfor 
-                        f <<  std::endl;
+                        f <<  "\n";
                 } endfor
 
                 f.close();
@@ -712,7 +712,7 @@ int parallel_graph_io::writeGraphWeightedParallelSimple(parallel_graph_access & 
                                 forall_out_edges(G, e, node) {
                                         f << " " <<   (G.getGlobalID(G.getEdgeTarget(e))+1) <<  " " <<  G.getEdgeWeight(e) ;
                                 } endfor 
-                                f <<  std::endl;
+                                f <<  "\n";
                         } endfor
                         f.close();
                 }
@@ -732,7 +732,7 @@ int parallel_graph_io::writeGraphWeightedSequentially(complete_graph_access & G,
                 forall_out_edges(G, e, node) {
                         f << " " <<   (G.getEdgeTarget(e)+1) <<  " " <<  G.getEdgeWeight(e) ;
                 } endfor 
-                f <<  std::endl;
+                f <<  "\n";
         } endfor
 
         f.close();
@@ -746,7 +746,7 @@ int parallel_graph_io::writeGraphSequentially(complete_graph_access & G, std::of
                 forall_out_edges(G, e, node) {
                         f << " " <<   (G.getEdgeTarget(e)+1)  ;
                 } endfor 
-                f <<  std::endl;
+                f <<  "\n";
         } endfor
         return 0;
 }


### PR DESCRIPTION
The current method for saving graphs in METIS format use one `std::endl` after each node. However, `std::endl` is not just a constant for the new line character but also flushes the stream (see http://en.cppreference.com/w/cpp/io/manip/endl). This lowers the writing speed significantly, in particular for graphs with many nodes of low degree. 

This PR replaces the `std::endl` with just a `\n` character. For 3-regular graphs, this improves the writing speed by a factor of about 9. 