### PR TITLE
Lower required CMake version and add CMake support for ParHIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ if(OPTIMIZED_OUTPUT)
   add_definitions("-DKAFFPAOUTPUT")
 endif()
 
+# ParHIP
+option(PARHIP "build ParHIP" ON)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
@@ -204,3 +206,9 @@ target_link_libraries(graphchecker libkaffpa libmapping ${OpenMP_CXX_LIBRARIES})
 add_executable(edge_partitioning app/spac.cpp)
 target_compile_definitions(edge_partitioning PRIVATE "-DMODE_KAFFPA")
 target_link_libraries(edge_partitioning libkaffpa libmapping libspac ${OpenMP_CXX_LIBRARIES})
+
+# ParHIP
+if(PARHIP)
+  add_subdirectory(parallel/modified_kahip)
+  add_subdirectory(parallel/parallel_src)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 include(CheckCXXCompilerFlag)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/parallel/modified_kahip/CMakeLists.txt
+++ b/parallel/modified_kahip/CMakeLists.txt
@@ -1,0 +1,81 @@
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
+include_directories(${MPI_CXX_INCLUDE_PATH})
+
+set(LIBMODIFIED_KAFFPA_SOURCE_FILES
+  lib/data_structure/graph_hierarchy.cpp
+  lib/algorithms/strongly_connected_components.cpp
+  lib/algorithms/topological_sort.cpp
+  lib/io/graph_io.cpp
+  lib/tools/quality_metrics.cpp
+  lib/tools/random_functions.cpp
+  lib/tools/graph_extractor.cpp
+  lib/tools/misc.cpp
+  lib/tools/partition_snapshooter.cpp
+  lib/partition/graph_partitioner.cpp
+  lib/partition/w_cycles/wcycle_partitioner.cpp
+  lib/partition/coarsening/coarsening.cpp
+  lib/partition/coarsening/contraction.cpp
+  lib/partition/coarsening/edge_rating/edge_ratings.cpp
+  lib/partition/coarsening/matching/matching.cpp
+  lib/partition/coarsening/matching/random_matching.cpp
+  lib/partition/coarsening/matching/gpa/path.cpp
+  lib/partition/coarsening/matching/gpa/gpa_matching.cpp
+  lib/partition/coarsening/matching/gpa/path_set.cpp
+  lib/partition/coarsening/clustering/node_ordering.cpp
+  lib/partition/coarsening/clustering/size_constraint_label_propagation.cpp
+  lib/partition/initial_partitioning/initial_partitioning.cpp
+  lib/partition/initial_partitioning/initial_partitioner.cpp
+  lib/partition/initial_partitioning/initial_partition_bipartition.cpp
+  lib/partition/initial_partitioning/initial_refinement/initial_refinement.cpp
+  lib/partition/initial_partitioning/bipartition.cpp
+  lib/partition/uncoarsening/uncoarsening.cpp
+  lib/partition/uncoarsening/separator/vertex_separator_algorithm.cpp
+  lib/partition/uncoarsening/separator/vertex_separator_flow_solver.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/greedy_neg_cycle.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/problem_factory.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph.cpp
+  lib/partition/uncoarsening/refinement/mixed_refinement.cpp
+  lib/partition/uncoarsening/refinement/label_propagation_refinement/label_propagation_refinement.cpp
+  lib/partition/uncoarsening/refinement/refinement.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/two_way_fm.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/two_way_flow_refinement.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/boundary_bfs.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/flow_solver.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/edge_cut_flow_solver.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/timer.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/most_balanced_minimum_cuts/most_balanced_minimum_cuts.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_refinement.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/complete_boundary.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/partial_boundary.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/quotient_graph_scheduling.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/simple_quotient_graph_scheduler.cpp
+  lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/active_block_quotient_graph_scheduler.cpp
+  lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.cpp
+  lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
+  lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/advanced_models.cpp
+  lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.cpp
+  lib/algorithms/cycle_search.cpp
+  lib/partition/uncoarsening/refinement/cycle_improvements/cycle_refinement.cpp
+  lib/parallel_mh/galinier_combine/gal_combine.cpp
+  lib/parallel_mh/galinier_combine/construct_partition.cpp
+  lib/partition/uncoarsening/refinement/tabu_search/tabu_search.cpp)
+add_library(libmodified_kaffpa ${LIBMODIFIED_KAFFPA_SOURCE_FILES})
+target_link_libraries(libmodified_kaffpa PRIVATE OpenMP::OpenMP_CXX)
+
+set(LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES
+  lib/parallel_mh/parallel_mh_async.cpp
+  lib/parallel_mh/population.cpp
+  lib/parallel_mh/exchange/exchanger.cpp
+  lib/tools/graph_communication.cpp
+  lib/tools/mpi_tools.cpp)
+add_library(libmodified_kaffpa_async ${LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES})
+
+add_library(libmodified_kahip_interface interface/kaHIP_interface.cpp)
+target_link_libraries(libmodified_kahip_interface PRIVATE libmodified_kaffpa_async libmodified_kaffpa)
+target_include_directories(libmodified_kahip_interface PUBLIC interface)

--- a/parallel/parallel_src/CMakeLists.txt
+++ b/parallel/parallel_src/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT OPTIMIZED_OUTPUT)
+  add_definitions("-DNOOUTPUT")
+endif()
+
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)

--- a/parallel/parallel_src/CMakeLists.txt
+++ b/parallel/parallel_src/CMakeLists.txt
@@ -1,0 +1,84 @@
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement)
+include_directories(${MPI_CXX_INCLUDE_PATH})
+link_libraries(OpenMP::OpenMP_CXX MPI::MPI_CXX)
+
+set(LIBPARALLEL_SOURCE_FILES
+  lib/data_structure/parallel_graph_access.cpp
+  lib/data_structure/balance_management.cpp
+  lib/data_structure/balance_management_refinement.cpp
+  lib/data_structure/balance_management_coarsening.cpp
+  lib/parallel_label_compress/node_ordering.cpp
+  lib/parallel_contraction_projection/parallel_contraction.cpp
+  lib/parallel_contraction_projection/parallel_block_down_propagation.cpp
+  lib/parallel_contraction_projection/parallel_projection.cpp
+  lib/distributed_partitioning/distributed_partitioner.cpp
+  lib/distributed_partitioning/initial_partitioning/initial_partitioning.cpp
+  lib/distributed_partitioning/initial_partitioning/distributed_evolutionary_partitioning.cpp
+  lib/distributed_partitioning/initial_partitioning/random_initial_partitioning.cpp
+  lib/communication/mpi_tools.cpp
+  lib/communication/dummy_operations.cpp
+  lib/io/parallel_graph_io.cpp
+  lib/io/parallel_vector_io.cpp
+  lib/tools/random_functions.cpp
+  lib/tools/distributed_quality_metrics.cpp
+  extern/argtable3-3.0.3/argtable3.c)
+add_library(libparallel ${LIBPARALLEL_SOURCE_FILES})
+target_link_libraries(libparallel PRIVATE libmodified_kahip_interface)
+
+set(LIBGRAPH2BGF_SOURCE_FILES
+  lib/data_structure/parallel_graph_access.cpp
+  lib/io/parallel_graph_io.cpp
+  lib/data_structure/balance_management.cpp
+  lib/data_structure/balance_management_refinement.cpp
+  lib/data_structure/balance_management_coarsening.cpp)
+add_library(libgraph2bf ${LIBGRAPH2BGF_SOURCE_FILES})
+
+set(LIBEDGELIST_SOURCE_FILES
+  lib/data_structure/parallel_graph_access.cpp
+  lib/io/parallel_graph_io.cpp
+  lib/data_structure/balance_management.cpp
+  lib/data_structure/balance_management_refinement.cpp
+  lib/data_structure/balance_management_coarsening.cpp
+  extern/argtable3-3.0.3/argtable3.c)
+add_library(libedgelist ${LIBEDGELIST_SOURCE_FILES})
+
+set(LIBDSPAC_SOURCE_FILES
+  lib/dspac/dspac.cpp
+  lib/dspac/edge_balanced_graph_io.cpp)
+add_library(libdspac ${LIBDSPAC_SOURCE_FILES})
+
+add_executable(parhip app/parhip.cpp)
+target_compile_definitions(parhip PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
+target_link_libraries(parhip libparallel)
+
+add_executable(toolbox app/toolbox.cpp)
+target_compile_definitions(toolbox PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DTOOLBOX")
+target_link_libraries(toolbox libparallel)
+
+add_executable(graph2binary app/graph2binary.cpp)
+target_compile_definitions(graph2binary PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION -DGRAPH2DGF")
+target_link_libraries(graph2binary libgraph2bf)
+
+add_executable(graph2binary_external app/graph2binary_external.cpp)
+target_compile_definitions(graph2binary_external PRIVATE "-DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION -DGRAPH2DGF")
+target_link_libraries(graph2binary_external libgraph2bf)
+
+add_executable(readbgf app/readbgf.cpp)
+target_compile_definitions(readbgf PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
+target_link_libraries(readbgf libgraph2bf)
+
+add_executable(edge_list_to_metis_graph app/edge_list_to_metis_graph.cpp)
+target_compile_definitions(edge_list_to_metis_graph PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DKRONECKER_GENERATOR_PROGRAM")
+target_link_libraries(edge_list_to_metis_graph libedgelist)
+
+add_executable(friendster_list_to_metis_graph app/friendster_list_to_metis_graph.cpp)
+target_compile_definitions(friendster_list_to_metis_graph PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DKRONECKER_GENERATOR_PROGRAM")
+target_link_libraries(friendster_list_to_metis_graph libedgelist)
+
+add_executable(dspac app/dspac.cpp)
+target_compile_definitions(dspac PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
+target_link_libraries(dspac libparallel libdspac)


### PR DESCRIPTION
CMake 3.12 is unavailable on some compute servers but CMake 3.10 seems to work too. I tested it on my PC and one of the compute servers. 