### PR TITLE
Add KaHIP and ParHIP interface to CMake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ set(LIBKAFFPA_SOURCE_FILES
   lib/partition/uncoarsening/refinement/cycle_improvements/cycle_refinement.cpp
   lib/partition/uncoarsening/refinement/tabu_search/tabu_search.cpp
   extern/argtable3-3.0.3/argtable3.c)
-add_library(libkaffpa ${LIBKAFFPA_SOURCE_FILES})
+add_library(libkaffpa OBJECT ${LIBKAFFPA_SOURCE_FILES})
 
 set(LIBKAFFPA_PARALLEL_SOURCE_FILES
   lib/parallel_mh/parallel_mh_async.cpp
@@ -151,7 +151,7 @@ set(LIBKAFFPA_PARALLEL_SOURCE_FILES
   lib/parallel_mh/exchange/exchanger.cpp
   lib/tools/graph_communication.cpp
   lib/tools/mpi_tools.cpp)
-add_library(libkaffpa_parallel ${LIBKAFFPA_PARALLEL_SOURCE_FILES})
+add_library(libkaffpa_parallel OBJECT ${LIBKAFFPA_PARALLEL_SOURCE_FILES})
 target_include_directories(libkaffpa_parallel PUBLIC ${MPI_CXX_INCLUDE_PATH})
 
 set(LIBMAPPING_SOURCE_FILES
@@ -163,9 +163,9 @@ set(LIBMAPPING_SOURCE_FILES
   lib/mapping/construct_distance_matrix.cpp
   lib/mapping/mapping_algorithms.cpp
   lib/mapping/construct_mapping.cpp)
-add_library(libmapping ${LIBMAPPING_SOURCE_FILES})
+add_library(libmapping OBJECT ${LIBMAPPING_SOURCE_FILES})
 
-set(LIBSPAC_SOURCE_FILES lib/spac/spac.cpp)
+set(LIBSPAC_SOURCE_FILES OBJECT lib/spac/spac.cpp)
 add_library(libspac ${LIBSPAC_SOURCE_FILES})
 
 # generate targets for each binary
@@ -206,6 +206,18 @@ target_link_libraries(graphchecker libkaffpa libmapping ${OpenMP_CXX_LIBRARIES})
 add_executable(edge_partitioning app/spac.cpp)
 target_compile_definitions(edge_partitioning PRIVATE "-DMODE_KAFFPA")
 target_link_libraries(edge_partitioning libkaffpa libmapping libspac ${OpenMP_CXX_LIBRARIES})
+
+# Shared interface library
+add_library(interface SHARED interface/kaHIP_interface.cpp)
+target_include_directories(interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+target_compile_definitions(interface PRIVATE "-DMODE_KAFFPA")
+target_link_libraries(interface PUBLIC libkaffpa libmapping ${OpenMP_CXX_LIBRARIES})
+
+# Static interface library
+add_library(interface_static interface/kaHIP_interface.cpp)
+target_include_directories(interface_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+target_compile_definitions(interface_static PRIVATE "-DMODE_KAFFPA")
+target_link_libraries(interface_static PUBLIC libkaffpa libmapping ${OpenMP_CXX_LIBRARIES})
 
 # ParHIP
 if(PARHIP)

--- a/parallel/modified_kahip/CMakeLists.txt
+++ b/parallel/modified_kahip/CMakeLists.txt
@@ -65,7 +65,7 @@ set(LIBMODIFIED_KAFFPA_SOURCE_FILES
   lib/parallel_mh/galinier_combine/gal_combine.cpp
   lib/parallel_mh/galinier_combine/construct_partition.cpp
   lib/partition/uncoarsening/refinement/tabu_search/tabu_search.cpp)
-add_library(libmodified_kaffpa ${LIBMODIFIED_KAFFPA_SOURCE_FILES})
+add_library(libmodified_kaffpa OBJECT ${LIBMODIFIED_KAFFPA_SOURCE_FILES})
 target_link_libraries(libmodified_kaffpa PRIVATE OpenMP::OpenMP_CXX)
 
 set(LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES
@@ -74,7 +74,7 @@ set(LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES
   lib/parallel_mh/exchange/exchanger.cpp
   lib/tools/graph_communication.cpp
   lib/tools/mpi_tools.cpp)
-add_library(libmodified_kaffpa_async ${LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES})
+add_library(libmodified_kaffpa_async OBJECT ${LIBMODIFIED_KAFFPA_PARALLEL_SOURCE_FILES})
 
 add_library(libmodified_kahip_interface interface/kaHIP_interface.cpp)
 target_link_libraries(libmodified_kahip_interface PRIVATE libmodified_kaffpa_async libmodified_kaffpa)

--- a/parallel/parallel_src/CMakeLists.txt
+++ b/parallel/parallel_src/CMakeLists.txt
@@ -2,6 +2,7 @@ if(NOT OPTIMIZED_OUTPUT)
   add_definitions("-DNOOUTPUT")
 endif()
 
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/app)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
@@ -30,7 +31,7 @@ set(LIBPARALLEL_SOURCE_FILES
   lib/tools/random_functions.cpp
   lib/tools/distributed_quality_metrics.cpp
   extern/argtable3-3.0.3/argtable3.c)
-add_library(libparallel ${LIBPARALLEL_SOURCE_FILES})
+add_library(libparallel OBJECT ${LIBPARALLEL_SOURCE_FILES})
 target_link_libraries(libparallel PRIVATE libmodified_kahip_interface)
 
 set(LIBGRAPH2BGF_SOURCE_FILES
@@ -39,7 +40,7 @@ set(LIBGRAPH2BGF_SOURCE_FILES
   lib/data_structure/balance_management.cpp
   lib/data_structure/balance_management_refinement.cpp
   lib/data_structure/balance_management_coarsening.cpp)
-add_library(libgraph2bf ${LIBGRAPH2BGF_SOURCE_FILES})
+add_library(libgraph2bf OBJECT ${LIBGRAPH2BGF_SOURCE_FILES})
 
 set(LIBEDGELIST_SOURCE_FILES
   lib/data_structure/parallel_graph_access.cpp
@@ -48,12 +49,12 @@ set(LIBEDGELIST_SOURCE_FILES
   lib/data_structure/balance_management_refinement.cpp
   lib/data_structure/balance_management_coarsening.cpp
   extern/argtable3-3.0.3/argtable3.c)
-add_library(libedgelist ${LIBEDGELIST_SOURCE_FILES})
+add_library(libedgelist OBJECT ${LIBEDGELIST_SOURCE_FILES})
 
 set(LIBDSPAC_SOURCE_FILES
   lib/dspac/dspac.cpp
   lib/dspac/edge_balanced_graph_io.cpp)
-add_library(libdspac ${LIBDSPAC_SOURCE_FILES})
+add_library(libdspac OBJECT ${LIBDSPAC_SOURCE_FILES})
 
 add_executable(parhip app/parhip.cpp)
 target_compile_definitions(parhip PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
@@ -86,3 +87,13 @@ target_link_libraries(friendster_list_to_metis_graph libedgelist)
 add_executable(dspac app/dspac.cpp)
 target_compile_definitions(dspac PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
 target_link_libraries(dspac libparallel libdspac)
+
+add_library(parhip_interface SHARED interface/parhip_interface.cpp)
+target_compile_definitions(parhip_interface PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
+target_include_directories(parhip_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+target_link_libraries(parhip_interface libparallel)
+
+add_library(parhip_interface_static interface/parhip_interface.cpp)
+target_compile_definitions(parhip_interface_static PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
+target_include_directories(parhip_interface_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
+target_link_libraries(parhip_interface_static libparallel)


### PR DESCRIPTION
Builds KaHIP and ParHIP interfaces as static and shared libraries. 

**Note:** I've changed the other libraries that are not part of the deployment to `OBJECT` libraries (in CMake), so that they are no longer built as separate static libraries (that should be the same behaviour as the scons scripts, I think). Is this ok or are there use cases for these sub-libraries (i.e. libkaffpa, libmapping, libkaffpa_parallel, libspac, ...)? I changed it because CMake would otherwise refuse to copy them into the interface libraries, although there also seem to be other solutions if those sub-libraries are needed. 