### PR TITLE
Use python3 prin formart in Scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -38,15 +38,15 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['optimized','optimized_output','debug']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   if not env['program'] in ['kaffpa', 'kaffpaE', 'partition_to_vertex_separator','improve_vertex_separator','library','graphchecker','label_propagation','evaluator','node_separator','spac']:
-    print 'Illegal value for program: %s' % env['program']
+    print('Illegal value for program: %s' % env['program'])
     sys.exit(1)
 
   if not env['mode'] in ['32bit','64bit']:
-    print 'Illegal value for mode: %s' % env['mode']
+    print('Illegal value for mode: %s' % env['mode'])
     sys.exit(1)
 
   # Special configuration for 64 bit machines.
@@ -127,4 +127,3 @@ if env['mode'] == '64bit':
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/interface/SConstruct
+++ b/interface/SConstruct
@@ -33,9 +33,9 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['debug', 'optimized', 'pdebug', 'profilingoptimized']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   # Special configuration for 64 bit machines.
   if platform.architecture()[0] == '64bit':
      env.Append(CPPFLAGS=['-DPOINTER64=1'])
@@ -67,8 +67,7 @@ else:
   # Debug settings.
   env.Append(CXXFLAGS = '-g -O0 -Wall -fno-stack-limit -Winline')
   env.Append(CCFLAGS = '-g -O0 -Winline')
- 
+
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/misc/example_library_call/SConstruct
+++ b/misc/example_library_call/SConstruct
@@ -53,11 +53,11 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['optimized','optimized_output','debug']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   if not env['program'] in ['interfacetest']:
-    print 'Illegal value for program: %s' % env['program']
+    print('Illegal value for program: %s' % env['program'])
     sys.exit(1)
 
   # Special configuration for 64 bit machines.
@@ -85,4 +85,3 @@ if env['variant'] == 'optimized':
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/parallel/modified_kahip/SConstruct
+++ b/parallel/modified_kahip/SConstruct
@@ -39,11 +39,11 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['optimized','optimized_output','debug']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   if not env['program'] in ['kaffpa', 'kaffpaE', 'partition_to_vertex_separator','library','graphchecker','label_propagation','interfacetest']:
-    print 'Illegal value for program: %s' % env['program']
+    print('Illegal value for program: %s' % env['program'])
     sys.exit(1)
 
   # Special configuration for 64 bit machines.
@@ -124,4 +124,3 @@ else:
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/parallel/modified_kahip/interface/SConstruct
+++ b/parallel/modified_kahip/interface/SConstruct
@@ -33,9 +33,9 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['debug', 'optimized', 'pdebug', 'profilingoptimized']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   # Special configuration for 64 bit machines.
   if platform.architecture()[0] == '64bit':
      env.Append(CPPFLAGS=['-DPOINTER64=1'])
@@ -67,8 +67,7 @@ else:
   # Debug settings.
   env.Append(CXXFLAGS = '-g -O0 -Wall -fno-stack-limit -Winline')
   env.Append(CCFLAGS = '-g -O0 -Winline')
- 
+
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/parallel/parallel_src/SConstruct
+++ b/parallel/parallel_src/SConstruct
@@ -39,11 +39,11 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['optimized','optimized_nooutput','debug']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   if not env['program'] in ['parhip','edge_list_to_metis_graph','friendster_list_to_metis_graph','parallel_label_compress_reps','yahoo_to_metis','parmetis_driver','graph2binary','graph2binary_external','readbgf','toolbox','dspac']:
-    print 'Illegal value for program: %s' % env['program']
+    print('Illegal value for program: %s' % env['program'])
     sys.exit(1)
 
   # Special configuration for 64 bit machines.
@@ -78,7 +78,7 @@ if SYSTEM == 'Darwin':
         env.Append(LIBPATH=['/opt/local/lib/'])
         # homebrew related paths
         env.Append(LIBPATH=['/usr/local/lib/'])
-        
+
 
 #if not conf.CheckCXXHeader('mpi.h'):
 	#print "openmpi header not found. Exiting"
@@ -123,4 +123,3 @@ else:
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-

--- a/parallel/parallel_src/interface/SConstruct
+++ b/parallel/parallel_src/interface/SConstruct
@@ -33,9 +33,9 @@ def GetEnvironment():
 
   env = Environment(options=opts, ENV=os.environ)
   if not env['variant'] in ['debug', 'optimized', 'pdebug', 'profilingoptimized']:
-    print 'Illegal value for variant: %s' % env['variant']
+    print('Illegal value for variant: %s' % env['variant'])
     sys.exit(1)
-  
+
   # Special configuration for 64 bit machines.
   if platform.architecture()[0] == '64bit':
      env.Append(CPPFLAGS=['-DPOINTER64=1'])
@@ -85,8 +85,7 @@ else:
   # Debug settings.
   env.Append(CXXFLAGS = '-g -O0 -Wall -fno-stack-limit -Winline -std=c++11')
   env.Append(CCFLAGS = '-g -O0 -Winline')
- 
+
 
 # Execute the SConscript.
 SConscript('SConscript', exports=['env'],variant_dir=env['variant'], duplicate=False)
-


### PR DESCRIPTION
-  These simple modifications allow the use of the `compile.sh` script in systems that have only python3