### PR TITLE
Add modified kahip lib to deploy/parallel

### DIFF
--- a/compile_withcmake.sh
+++ b/compile_withcmake.sh
@@ -13,7 +13,7 @@ fi
 rm -rf deploy
 rm -rf build
 mkdir build
-cd build 
+cd build
 cmake ../
 make -j $NCORES
 cd ..
@@ -36,4 +36,6 @@ cp ./build/parallel/parallel_src/libparhip_inter*.a deploy/libparhip.a
 cp ./interface/kaHIP_interface.h deploy/
 cp ./parallel/parallel_src/interface/parhip_interface.h deploy/
 
+mkdir deploy/parallel
+cp ./build/parallel/modified_kahip/lib*.a deploy/parallel/libkahip.a
 


### PR DESCRIPTION
`libkahip` from the `parallel/modified/deploy` has also to be linked if one intends to use the parhip interface. However, using `compile_withcmake.sh` the lib file is not located in the usual deploy folder.

Proposal:
Add the modified kahip lib to deploy/parallel.