### PR TITLE
Make OpenMP an optional dependency

### DIFF
--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
@@ -5,7 +5,9 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
+#ifdef USE_OPENMP
 #include <omp.h>
+#endif
 
 #include "kway_graph_refinement_commons.h"
 
@@ -20,16 +22,23 @@ kway_graph_refinement_commons::~kway_graph_refinement_commons() {
 
 
 kway_graph_refinement_commons* kway_graph_refinement_commons::getInstance( PartitionConfig & config ) {
-
+        #ifdef USE_OPENMP
+        int max_threads = omp_get_max_threads();
+        #else
+        int  max_threads = 1;
+        #endif
         bool created = false;
-        #pragma omp critical 
+        #pragma omp critical
         {
                 if( m_instances == NULL ) {
-                        m_instances = new std::vector< kway_graph_refinement_commons*>(omp_get_max_threads(), NULL);
+                        m_instances = new std::vector< kway_graph_refinement_commons*>(max_threads, NULL);
                 }
-        } 
-
+        }
+        #ifdef USE_OPENMP
         int id = omp_get_thread_num();
+        #else
+        int id = 0;
+        #endif
         if((*m_instances)[id] == NULL) {
                 (*m_instances)[id] = new kway_graph_refinement_commons();
                 (*m_instances)[id]->init(config);
@@ -38,8 +47,8 @@ kway_graph_refinement_commons* kway_graph_refinement_commons::getInstance( Parti
 
         if(created == false) {
                 if(config.k != (*m_instances)[id]->getUnderlyingK()) {
-                        //should be a very rare case 
-                        (*m_instances)[id]->init(config); 
+                        //should be a very rare case
+                        (*m_instances)[id]->init(config);
                 }
         }
 

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
@@ -22,13 +22,13 @@ kway_graph_refinement_commons::~kway_graph_refinement_commons() {
 
 
 kway_graph_refinement_commons* kway_graph_refinement_commons::getInstance( PartitionConfig & config ) {
+        bool created = false;
         #ifdef USE_OPENMP
         int max_threads = omp_get_max_threads();
+        #pragma omp critical
         #else
         int  max_threads = 1;
         #endif
-        bool created = false;
-        #pragma omp critical
         {
                 if( m_instances == NULL ) {
                         m_instances = new std::vector< kway_graph_refinement_commons*>(max_threads, NULL);


### PR DESCRIPTION
Trivial changes to build KaHIP  without OpenMP.

We have an open PR in FEniCS/dolfinx, for using KaHIP as the mesh partitioner
([#451](https://github.com/FEniCS/dolfinx/pull/451)). However OpenMP is a large dependecy that we are currently avoiding. 
This PR would allow the use of KaHIP in FEniCS, and get the mentioned PR merged.
