### PR TITLE
Fix Open MPI url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ The graph partitioning problem asks for a division of a graph's node set into k 
 
 
 ## Main project site:
-http://algo2.iti.kit.edu/documents/kahip/index.html
+https://algo2.iti.kit.edu/documents/kahip/index.html
 
 Installation Notes
 =====
 
 Before you can start you need to install the following software packages:
 
-- Scons (http://www.scons.org/)
-- OpenMPI (http://www.open-mpi.de/). Note: due to removed progress threads in OpenMPI > 1.8, please use an OpenMPI version < 1.8 or Intel MPI to obtain a scalable parallel algorithm.
+- Scons (https://www.scons.org/)
+- OpenMPI (https://www.open-mpi.org/). Note: due to removed progress threads in OpenMPI > 1.8, please use an OpenMPI version < 1.8 or Intel MPI to obtain a scalable parallel algorithm.
 
 Once you installed the packages, just type ./compile.sh. Once you did that you can try to run the following command:
 


### PR DESCRIPTION
The link to the Open MPI project was broken. It now points to the correct website.